### PR TITLE
Update README.md

### DIFF
--- a/Animal Data Standards/README.md
+++ b/Animal Data Standards/README.md
@@ -96,4 +96,4 @@ This document is part of a work stream focusing on Data Standards for interchang
 
 [CT Scan](http://www.mayoclinic.org/tests-procedures/ct-scan/basics/definition/prc-20014610) Mayo Clinic.
 
-[Mid-Infrared Spectroscopy](http://ritchie.chem.ox.ac.uk/research_files/midirspectroscopy.htm) The Ritchie Group – University of Oxford.
+[Mid-Infrared Spectroscopy](https://ritchie.web.ox.ac.uk/medicine) The Ritchie Group – University of Oxford.

--- a/Animal Data Standards/README.md
+++ b/Animal Data Standards/README.md
@@ -96,4 +96,4 @@ This document is part of a work stream focusing on Data Standards for interchang
 
 [CT Scan](http://www.mayoclinic.org/tests-procedures/ct-scan/basics/definition/prc-20014610) Mayo Clinic.
 
-[Mid-Infrared Spectroscopy] The Ritchie Group – University of Oxford.
+Mid-Infrared Spectroscopy The Ritchie Group – University of Oxford.

--- a/Animal Data Standards/README.md
+++ b/Animal Data Standards/README.md
@@ -96,4 +96,4 @@ This document is part of a work stream focusing on Data Standards for interchang
 
 [CT Scan](http://www.mayoclinic.org/tests-procedures/ct-scan/basics/definition/prc-20014610) Mayo Clinic.
 
-[Mid-Infrared Spectroscopy](https://ritchie.web.ox.ac.uk/medicine) The Ritchie Group – University of Oxford.
+[Mid-Infrared Spectroscopy] The Ritchie Group – University of Oxford.


### PR DESCRIPTION
Change from http://ritchie.chem.ox.ac.uk/research_files/midirspectroscopy.htm
to
https://ritchie.web.ox.ac.uk/medicine as Page not found error. Current website there is no specific Infrared spectroscopy page but there is one page that gives information about infrared spectroscopy

